### PR TITLE
Add internal links to README and index.md for better navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,57 +21,57 @@ Bu rehber, .NET backend geliştiricilerinin mülakat süreçlerinde karşılaşa
 
 ### Junior Developer Mülakat Hazırlığı
 
-#### 1. Temel .NET Kavramları
-- .NET Framework vs .NET Core
-- CLR
-- Managed ve Unmanaged Code
-- Assembly ve Namespace
-- Garbage Collection
+#### [1. Temel .NET Kavramları](./docs/junior/basic-dotnet-concepts/index.md)
+- [.NET Framework vs .NET Core](./docs/junior/basic-dotnet-concepts/framework-vs-core.md)
+- [CLR](./docs/junior/basic-dotnet-concepts/clr.md)
+- [Managed ve Unmanaged Code](./docs/junior/basic-dotnet-concepts/managed-unmanaged.md)
+- [Assembly ve Namespace](./docs/junior/basic-dotnet-concepts/assembly-namespace.md)
+- [Garbage Collection](./docs/junior/basic-dotnet-concepts/garbage-collection.md)
 
-#### 2. Algoritmalar
-- Array Algorithms
-- String Algorithms
-- Number Algorithms
-- Dynamic Programming
-- Sorting Algorithms
-- Linked List Algorithms
-- Tree Algorithms
-- Hash Table Algorithms
+#### [2. Algoritmalar](./docs/junior/algorithms/index.md)
+- [Array Algorithms](./docs/junior/algorithms/array-algorithms.md)
+- [String Algorithms](./docs/junior/algorithms/string-algorithms.md)
+- [Number Algorithms](./docs/junior/algorithms/number-algorithms.md)
+- [Dynamic Programming](./docs/junior/algorithms/dynamic-programming.md)
+- [Sorting Algorithms](./docs/junior/algorithms/sorting-algorithms.md)
+- [Linked List Algorithms](./docs/junior/algorithms/linked-list-algorithms.md)
+- [Tree Algorithms](./docs/junior/algorithms/tree-algorithms.md)
+- [Hash Table Algorithms](./docs/junior/algorithms/hash-table-algorithms.md)
 
-#### 3. C# Temelleri
-- Temel Veri Tipleri
-- Kontrol Yapıları
-- Nesne Yönelimli Programlama
-- Koleksiyonlar
-- Delegates ve Events
+#### [3. C# Temelleri](./docs/junior/csharp-basics/index.md)
+- [Temel Veri Tipleri](./docs/junior/csharp-basics/basic-data-types.md)
+- [Kontrol Yapıları](./docs/junior/csharp-basics/control-structures.md)
+- [Nesne Yönelimli Programlama](./docs/junior/csharp-basics/oop.md)
+- [Koleksiyonlar](./docs/junior/csharp-basics/collections.md)
+- [Delegates ve Events](./docs/junior/csharp-basics/delegates-events.md)
 
-#### 4. ASP.NET Core Temelleri
-- Middleware
-- Dependency Injection
-- Routing
-- Model Binding
-- Validation
+#### [4. ASP.NET Core Temelleri](./docs/junior/aspnet-core-basics/index.md)
+- [Middleware](./docs/junior/aspnet-core-basics/middleware.md)
+- [Dependency Injection](./docs/junior/aspnet-core-basics/dependency-injection.md)
+- [Routing](./docs/junior/aspnet-core-basics/routing.md)
+- [Model Binding](./docs/junior/aspnet-core-basics/model-binding.md)
+- [Validation](./docs/junior/aspnet-core-basics/validation.md)
 
-#### 5. Veritabanı İşlemleri
-- Entity Framework Core
-- LINQ
-- Migrations
-- Transactions
-- Performance
+#### [5. Veritabanı İşlemleri](./docs/junior/database-operations/index.md)
+- [Entity Framework Core](./docs/junior/database-operations/entity-framework-core.md)
+- [LINQ](./docs/junior/database-operations/linq.md)
+- [Migrations](./docs/junior/database-operations/migrations.md)
+- [Transactions](./docs/junior/database-operations/transactions.md)
+- [Performance](./docs/junior/database-operations/performance.md)
 
-#### 6. API Geliştirme
-- REST API
-- HTTP Methods
-- Status Codes
-- API Versioning
-- API Documentation
+#### [6. API Geliştirme](./docs/junior/api-development/index.md)
+- [REST API](./docs/junior/api-development/rest-api.md)
+- [HTTP Methods](./docs/junior/api-development/http-methods.md)
+- [Status Codes](./docs/junior/api-development/status-codes.md)
+- [API Versioning](./docs/junior/api-development/api-versioning.md)
+- [API Documentation](./docs/junior/api-development/api-documentation.md)
 
-#### 7. Güvenlik Temelleri
-- Authentication
-- Authorization
-- HTTPS
-- CORS
-- Input Validation
+#### [7. Güvenlik Temelleri](./docs/junior/security-basics/index.md)
+- [Authentication](./docs/junior/security-basics/authentication.md)
+- [Authorization](./docs/junior/security-basics/authorization.md
+- [HTTPS](./docs/junior/security-basics/https.md)
+- [CORS](./docs/junior/security-basics/cors.md)
+- [Input Validation](./docs/junior/security-basics/input-validation.md)
 
 #### 8. Mülakat Örnekleri
 - Her örnek 20 soru içerir
@@ -81,75 +81,75 @@ Bu rehber, .NET backend geliştiricilerinin mülakat süreçlerinde karşılaşa
 
 ### Mid-Level Developer Mülakat Hazırlığı
 
-#### 1. İleri C# Konuları
-- Async/Await
-- LINQ Advanced
-- Reflection
-- Attributes
-- Expression Trees
+#### [1. İleri C# Konuları](./docs/mid-level/advanced-csharp/index.md)
+- [Async/Await](./docs/mid-level/advanced-csharp/async-await.md)
+- [LINQ Advanced](./docs/mid-level/advanced-csharp/linq-advanced.md)
+- [Reflection](./docs/mid-level/advanced-csharp/reflection.md)
+- [Attributes](./docs/mid-level/advanced-csharp/attributes.md)
+- [Expression Trees](./docs/mid-level/advanced-csharp/expression-trees.md)
 
-#### 2. Design Patterns
-- Creational Patterns
-- Structural Patterns
-- Behavioral Patterns
-- Repository Pattern
-- Unit of Work
+#### [2. Design Patterns](./docs/mid-level/design-patterns/index.md)
+- [Creational Patterns](./docs/mid-level/design-patterns/creational-patterns.md)
+- [Structural Patterns](./docs/mid-level/design-patterns/structural-patterns.md)
+- [Behavioral Patterns](./docs/mid-level/design-patterns/behavioral-patterns.md)
+- [Repository Pattern](./docs/mid-level/design-patterns/repository-pattern.md)
+- [Unit of Work](./docs/mid-level/design-patterns/unit-of-work.md)
 
-#### 3. SOLID Prensipleri
-- Single Responsibility
-- Open/Closed
-- Liskov Substitution
-- Interface Segregation
-- Dependency Inversion
+#### [3. SOLID Prensipleri](./docs/mid-level/solid-principles/index.md)
+- [Single Responsibility](./docs/mid-level/solid-principles/single-responsibility.md)
+- [Open/Closed](./docs/mid-level/solid-principles/open-closed.md)
+- [Liskov Substitution](./docs/mid-level/solid-principles/liskov-substitution.md)
+- [Interface Segregation](./docs/mid-level/solid-principles/interface-segregation.md)
+- [Dependency Inversion](./docs/mid-level/solid-principles/dependency-inversion.md)
 
-#### 4. Clean Architecture
-- Domain Layer
-- Application Layer
-- Infrastructure Layer
-- Presentation Layer
-- Cross-Cutting Concerns
+#### [4. Clean Architecture](./docs/mid-level/clean-architecture/index.md)
+- [Domain Layer](./docs/mid-level/clean-architecture/domain-layer.md)
+- [Application Layer](./docs/mid-level/clean-architecture/application-layer.md)
+- [Infrastructure Layer](./docs/mid-level/clean-architecture/infrastructure-layer.md)
+- [Presentation Layer](./docs/mid-level/clean-architecture/presentation-layer.md)
+- [Cross-Cutting Concerns](./docs/mid-level/clean-architecture/cross-cutting-concerns.md)
 
-#### 5. Microservices
-- Service Communication
-- API Gateway
-- Service Discovery
-- Circuit Breaker
-- Event Sourcing
+#### [5. Microservices](./docs/mid-level/microservices/index.md)
+- [Service Communication](./docs/mid-level/microservices/service-communication.md)
+- [API Gateway](./docs/mid-level/microservices/api-gateway.md)
+- [Service Discovery](./docs/mid-level/microservices/service-discovery.md)
+- [Circuit Breaker](./docs/mid-level/microservices/circuit-breaker.md)
+- [Event Sourcing](./docs/mid-level/microservices/event-sourcing.md)
 
-#### 6. Performance Optimization
-- Caching
-- Database Optimization
-- Memory Management
-- Async Programming
-- Profiling
+#### [6. Performance Optimization](./docs/mid-level/performance-optimization/index.md)
+- [Caching](./docs/mid-level/performance-optimization/caching.md)
+- [Database Optimization](./docs/mid-level/performance-optimization/database-optimization.md)
+- [Memory Management](./docs/mid-level/performance-optimization/memory-management.md)
+- [Async Programming](./docs/mid-level/performance-optimization/async-programming.md)
+- [Profiling](./docs/mid-level/performance-optimization/profiling.md)
 
-#### 7. Testing
-- Unit Testing
-- Integration Testing
-- Test Driven Development
-- Mocking
-- Code Coverage
+#### [7. Testing](./docs/mid-level/testing/index.md)
+- [Unit Testing](./docs/mid-level/testing/unit-testing.md)
+- [Integration Testing](./docs/mid-level/testing/integration-testing.md)
+- [Test Driven Development](./docs/mid-level/testing/tdd.md)
+- [Mocking](./docs/mid-level/testing/mocking.md)
+- [Code Coverage](./docs/mid-level/testing/test-coverage.md)
 
-#### 8. Logging ve Monitoring
+#### [8. Logging ve Monitoring](./docs/mid-level/logging-monitoring/index.md)
 - Logging Best Practices
-- Application Insights
-- ELK Stack
-- Performance Monitoring
+- [Application Insights](./docs/mid-level/logging-monitoring/application-insights.md)
+- [ELK Stack](./docs/mid-level/logging-monitoring/serilog-elk.md)
+- [Performance Monitoring](./docs/mid-level/logging-monitoring/performance-monitoring.md)
 - Error Tracking
 
-#### 9. Message Queue
-- RabbitMQ
+#### [9. Message Queue](./docs/mid-level/message-queue/index.md)
+- [RabbitMQ](./docs/mid-level/message-queue/rabbitmq.md)
 - Azure Service Bus
-- Kafka
+- [Kafka](./docs/mid-level/message-queue/kafka.md)
 - Message Patterns
 - Event Driven Architecture
 
-#### 10. Entity Framework
-- Advanced Queries
-- Performance Tuning
-- Migrations
-- Raw SQL
-- Change Tracking
+#### [10. Entity Framework](./docs/mid-level/entity-framework/index.md)
+- [Advanced Queries](./docs/mid-level/entity-framework/advanced-querying.md)
+- [Performance Tuning](./docs/mid-level/entity-framework/performance-optimization.md)
+- [Migrations](./docs/mid-level/entity-framework/custom-migrations.md)
+- [Raw SQL](./docs/mid-level/entity-framework/raw-sql.md)
+- [Change Tracking](./docs/mid-level/entity-framework/change-tracking.md)
 
 #### 11. Mülakat Örnekleri
 - Her örnek 20 soru içerir
@@ -159,33 +159,33 @@ Bu rehber, .NET backend geliştiricilerinin mülakat süreçlerinde karşılaşa
 
 ### Senior Developer Mülakat Hazırlığı
 
-#### 1. System Design
-- Scalability
-- High Availability
-- Load Balancing
-- Caching Strategies
-- Database Sharding
+#### [1. System Design](./docs/senior/system-design/index.md)
+- [Scalability](./docs/senior/system-design/scalability.md)
+- [High Availability](./docs/senior/system-design/high-availability.md)
+- [Load Balancing](./docs/senior/system-design/load-balancing.md)
+- [Caching Strategies](./docs/senior/system-design/caching-strategies.md)
+- [Database Sharding](./docs/senior/system-design/database-sharding.md)
 
-#### 2. Cloud Architecture
-- Azure Services
-- AWS Services
-- Containerization
-- Serverless
-- Cloud Security
+#### [2. Cloud Architecture](./docs/senior/cloud-architecture/index.md)
+- [Azure Services](./docs/senior/cloud-architecture/azure-services.md)
+- [AWS Services](./docs/senior/cloud-architecture/aws-services.md)
+- [Containerization](./docs/senior/cloud-architecture/containerization.md)
+- [Serverless](./docs/senior/cloud-architecture/serverless.md)
+- [Cloud Security](./docs/senior/cloud-architecture/cloud-security.md)
 
-#### 3. DevOps Practices
-- CI/CD
-- Infrastructure as Code
-- Monitoring
-- Logging
-- Deployment Strategies
+#### [3. DevOps Practices](./docs/senior/devops-practices/index.md)
+- [CI/CD](./docs/senior/devops-practices/ci-cd.md)
+- [Infrastructure as Code](./docs/senior/devops-practices/infrastructure-as-code.md)
+- [Monitoring](./docs/senior/devops-practices/monitoring.md)
+- [Logging](./docs/senior/devops-practices/logging.md)
+- [Deployment Strategies](./docs/senior/devops-practices/deployment-strategies.md)
 
-#### 4. Advanced Security
-- OAuth2
-- OpenID Connect
-- JWT
-- Security Headers
-- Penetration Testing
+#### [4. Advanced Security](./docs/senior/advanced-security/index.md)
+- [OAuth2](./docs/senior/advanced-security/oauth2.md)
+- [OpenID Connect](./docs/senior/advanced-security/openid-connect.md)
+- [JWT](./docs/senior/advanced-security/jwt.md)
+- [Security Headers](./docs/senior/advanced-security/security-headers.md)
+- [Penetration Testing](./docs/senior/advanced-security/penetration-testing.md)
 
 #### 5. Mülakat Örnekleri
 - Her örnek 20 soru içerir

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,7 @@ Bu rehber, .NET backend geliştiricilerinin mülakat süreçlerinde başarılı 
 
 ## 🤝 İletişim ve Takip
 
-- GitHub: [muratdincc](https://github.com/muratdincc)
+- GitHub: [muratdinc](https://github.com/muratdincc)
 - LinkedIn: [Murat Dinç](https://www.linkedin.com/in/muratdincc)
 - Medium: [Murat Dinç](https://medium.com/@muratdincc)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,7 @@ Bu rehber, .NET backend geliştiricilerinin mülakat süreçlerinde başarılı 
 
 ## 🤝 İletişim ve Takip
 
-- GitHub: [muratdinc](https://github.com/muratdincc)
+- GitHub: [muratdincc](https://github.com/muratdincc)
 - LinkedIn: [Murat Dinç](https://www.linkedin.com/in/muratdincc)
 - Medium: [Murat Dinç](https://medium.com/@muratdincc)
 


### PR DESCRIPTION
Added internal links in the main README.md to navigate directly to related topic-specific .md files,
in order to improve accessibility and allow readers to quickly jump to detailed content without manually searching through the repository.