### PR TITLE
Add dark/light mode toggle and footer with social links

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,19 @@ edit_uri: edit/main/docs/
 
 theme:
   name: material
+  palette:
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Karanlık moda geç
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Aydınlık moda geç
   features:
     - navigation.tabs
     - navigation.sections
@@ -19,6 +32,17 @@ theme:
     - content.code.annotate
     - content.code.copy
     - content.action.edit
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/MuratDincc
+      name: GitHub
+    - icon: fontawesome/brands/linkedin
+      link: https://linkedin.com/in/muratdincc
+      name: LinkedIn
+
+copyright: Copyright &copy; 2024 - 2026 Murat Dinc
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
- Added palette configuration with default (light) and slate (dark) scheme toggle
- Added GitHub and LinkedIn social links to the footer
- Added copyright notice

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-site configuration changes limited to `mkdocs.yml` (theme styling and footer metadata only).
> 
> **Overview**
> Adds a Material theme **light/dark mode** palette configuration with a UI toggle.
> 
> Updates `mkdocs.yml` to include **footer metadata** via `extra.social` (GitHub/LinkedIn links) and a site-wide `copyright` notice.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dfeaa3a3080ea0d416a89a02886f0b81bec0c9be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->